### PR TITLE
generic error handling for get_model_response in Demo QA notebook

### DIFF
--- a/examples/demo_question_answering.ipynb
+++ b/examples/demo_question_answering.ipynb
@@ -816,7 +816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 77,
    "id": "e67c04f7",
    "metadata": {},
    "outputs": [],
@@ -850,7 +850,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 78,
    "id": "f39aa4c9",
    "metadata": {},
    "outputs": [],
@@ -863,7 +863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 79,
    "id": "1ec5b222",
    "metadata": {},
    "outputs": [],
@@ -874,18 +874,82 @@
     "        filled_prompt = QA_prompt.replace(\n",
     "            \"<context>\", clothing_df.source_text[i]).replace(\n",
     "            \"<question>\", test_case.input)\n",
-    "        responses.append(model_fn(filled_prompt))\n",
+    "        try:\n",
+    "            response = model_fn(filled_prompt)\n",
+    "        except Exception as e:\n",
+    "            response = f\"ERROR: API call to LLM failed: {e}\"\n",
+    "        responses.append(response)\n",
     "    return responses"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 80,
    "id": "3ea2822b",
    "metadata": {},
    "outputs": [],
    "source": [
     "chatgpt_responses = get_responses(chatgpt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "c3dd6c87",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['The Plumanoix athletic shirt is made from a blend of moisture-wicking and breathable materials.',\n",
+       " 'The fabric of the Athletic Shirt 2.0 from Clothimus Universum is high-quality, moisture-wicking fabric.',\n",
+       " 'The fabric of the Shimmer Threads Athletic Shirt is made from a high-performance blend of moisture-wicking fabric. The benefits of this fabric include being lightweight, breathable, and quick-drying, ensuring comfort and dryness during intense workouts.',\n",
+       " 'The Athletic Shirt from ZorbyX Fashionista is made from high-quality, breathable materials.',\n",
+       " 'The Zephyr Threads Shirt is made from high-quality cotton, making it soft, breathable, and comfortable to wear.',\n",
+       " 'The Plumanoix Performance Pants feature moisture-wicking technology that draws sweat away from your skin, helping to keep you dry during your workout.',\n",
+       " 'The Performance Pants feature an elastic waistband and drawstring closure to ensure a secure and customized fit.',\n",
+       " 'The available colors of the Shimmering Satin Pants from Shimmer Threads are champagne and rose gold.',\n",
+       " 'These ZorbyX fashionista pants are made with a blend of premium fabrics.',\n",
+       " 'The fabric blend used to make the Zephyr Threads Casual Pants is a luxurious blend of cotton and elastane. This blend offers maximum comfort and durability, as cotton is known for its breathability and softness, while elastane provides the pants with stretch and flexibility.',\n",
+       " 'These Plumanoix casual shoes have a classic lace-up closure.',\n",
+       " 'The upper part of the Clothimus Universum Athletic Shoes is made from a breathable mesh material.',\n",
+       " 'The sole of the Shimmer Threads casual shoes is made of a sturdy rubber material.',\n",
+       " 'The upper part of the ZorbyX Fashionista Athletic Shoe is made of breathable mesh.',\n",
+       " \"The uppers of Zephyr Threads' Casual Slip-On shoes are made from a durable canvas material.\",\n",
+       " \"Some of the features that make the Plumanoix Swimsuit stand out from other athletic swimsuits on the market are:\\n\\n1. High-quality, durable materials: The swimsuit is built to last, ensuring it can withstand rigorous training sessions.\\n\\n2. Sleek and modern design: The Plumanoix Swimsuit not only looks great but also provides excellent support and flexibility.\\n\\n3. Superior comfort and breathability: The unique fabric blend of the swimsuit offers exceptional comfort, breathability, and moisture-wicking properties, keeping you cool and dry during intense training sessions.\\n\\n4. Compression fit: The swimsuit's compression fit promotes excellent blood flow and muscle recovery, helping you stay energized and focused.\\n\\n5. Wide range of sizes and colors: The Plumanoix Swimsuit is available in various sizes and colors, making it suitable for athletes of all shapes and sizes.\\n\\nOverall, the Plumanoix Swimsuit offers a combination of performance and comfort, making it a top choice for serious athletes in the market for a new swimsuit.\",\n",
+       " 'The Clothimus Universum Swimsuit features built-in adjustable straps, which provide extra support and ensure a perfect fit.',\n",
+       " 'The Shimmer Threads casual swimsuit is made from a high-quality blend of polyester and spandex materials.',\n",
+       " 'Some of the features that make the ZorbyX Fashionista luxury swimsuit stand out are its sleek and modern design, bold color choices, unique patterns, adjustable straps for a perfect fit, attention to detail in stitching and hardware, and the flattering cut and strategic placement of seams to enhance natural curves. Additionally, the swimsuit is made from a blend of premium materials that provide exceptional comfort and durability, with a soft and lightweight fabric that is perfect for all-day wear.',\n",
+       " 'The Zephyr Threads swimsuit is made of premium quality fabric.',\n",
+       " 'The Plumanoix Hoodie is made from high-quality materials that are breathable, moisture-wicking, and ultra-soft against your skin. This fabric is ideal for intense workouts because it allows for proper ventilation, keeps you dry by wicking away sweat, and provides a comfortable feel.',\n",
+       " \"The notable features of Clothimus Universum's Hoodie that make it a perfect addition to an athlete's wardrobe include:\\n\\n1. High-quality materials: The Hoodie is made with premium materials that provide maximum comfort and durability during workouts, ensuring it can withstand the rigors of athletic activities.\\n\\n2. Comfortable and stylish design: The Hoodie has a comfortable fit that allows for maximum range of motion without compromising on style. It features a sleek and modern design that is sure to turn heads.\\n\\n3. Adjustable hood and drawstrings: The Hoodie's hood comes with adjustable drawstrings, allowing for a customizable fit. This ensures that athletes can comfortably wear the Hoodie according to their preferences.\\n\\n4. Front pocket for convenience: With a front pocket, the Hoodie provides easy storage for essentials such as keys, phones, or small items during workouts. This adds to the functionality and convenience of the Hoodie.\\n\\n5. Vibrant color options: The Hoodie is available in a range of vibrant colors, allowing athletes to express their personal style while staying active. Athletes can choose a color that suits their taste or matches their other workout attire.\\n\\nOverall, the Clothimus Universum Hoodie combines style, functionality, and durability, making it the perfect addition to any athlete's wardrobe.\",\n",
+       " 'The casual hoodie from Shimmer Threads is made with a soft and comfortable cotton blend.',\n",
+       " 'The ZorbyX Fashionista Hoodie is available in sizes ranging from small to XXL.',\n",
+       " 'The Zephyr Threads athletic hoodie features ribbed cuffs and hem for a snug fit, a drawstring hood for adjustable fit, and a range of sizes available to ensure a comfortable fit for any individual.',\n",
+       " 'The Plumanoix casual backpack features adjustable padded shoulder straps that ensure comfortable carrying, even for long periods of time. These straps can be easily customized to your preferred fit, providing optimal support for your shoulders and back. Additionally, the backpack is crafted from high-quality materials that are durable yet lightweight, further enhancing comfort during extended wear.',\n",
+       " 'The Clothimus Universum luxury backpack is made of premium quality leather.',\n",
+       " 'The main compartment of the Shimmer Threads luxury backpack has a zippered closure.',\n",
+       " 'The unique features of the ZorbyX Fashionista Athletic Backpack include a durable and water-resistant exterior, spacious main compartment with a zippered closure, two convenient zippered front pockets, adjustable padded straps for a comfortable fit, a trendy color block pattern, and the signature ZorbyX logo.',\n",
+       " 'The Zephyr Threads Athletic Backpack has multiple compartments and pockets for storing items. It features a main compartment, side pockets for a water bottle, a front pocket for a phone and keys, and a mesh pocket on the back for additional storage.',\n",
+       " 'The Plumanoix casual hat is made from a durable yet breathable fabric.',\n",
+       " 'The design of the Clothimus Universum luxury hat is sleek and timeless, making it suitable for any occasion.',\n",
+       " 'The available sizes for the Shimmer Threads Casual Hat are not provided in the given context. It is recommended to check the product listing or contact the brand directly for information on available sizes.',\n",
+       " 'The ZorbyX Fashionista casual hat is made from a soft, lightweight, and breathable fabric.',\n",
+       " 'The Athletic Hat from Zephyr Threads is made from a blend of durable and lightweight materials.',\n",
+       " 'The Plumanoix Leggings are made from a high-quality blend of spandex and polyester. This material composition offers unbeatable stretch and support, which is beneficial for wearers during workouts. The stretch allows for freedom of movement and flexibility, while the support helps to stabilize muscles and prevent strain. Additionally, the fabric is breathable and sweat-wicking, ensuring that the wearer stays cool and dry even during intense workouts.',\n",
+       " 'The Clothimus Universum Leggings are made from high-quality, moisture-wicking fabric. This fabric helps to keep you feeling dry and comfortable by wicking away sweat and moisture from your body during athletic activities.',\n",
+       " 'The Shimmer Threads Leggings are designed with flatlock seams to prevent chafing and irritation during workouts.',\n",
+       " 'The key feature of the waistband on the ZorbyX Fashionista athletic leggings is that it provides extra support and coverage.',\n",
+       " 'The main design feature of the Zephyr Threads High-Waisted Leggings that provides extra support and coverage is their high-waisted design.']"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chatgpt_responses"
    ]
   },
   {


### PR DESCRIPTION
added generic error handling to the demo QA notebook so that the note book runs even if there are errors from the LLM API