### PR TITLE
remove extra field discrepancy with REST API

### DIFF
--- a/arthur_bench/client/local/client.py
+++ b/arthur_bench/client/local/client.py
@@ -386,7 +386,6 @@ class LocalBenchClient(BenchClient):
         pagination = _paginate(runs, page, page_size, sort_key=sort)
 
         return PaginatedRuns(
-            test_suite_id=uuid.UUID(test_suite_id),
             test_runs=pagination.sorted_pages[pagination.start : pagination.end],
             page_size=pagination.page_size,
             page=pagination.page,

--- a/arthur_bench/models/models.py
+++ b/arthur_bench/models/models.py
@@ -208,7 +208,6 @@ class PaginatedRuns(BaseModel):
     Paginated list of runs for a test suite.
     """
 
-    test_suite_id: UUID
     test_runs: List[TestRunMetadata]
     page: int
     page_size: int

--- a/tests/fixtures/mock_responses.py
+++ b/tests/fixtures/mock_responses.py
@@ -233,7 +233,6 @@ MOCK_RUNS_RESPONSE = PaginatedRuns(
             avg_score=0.8,
         )
     ],
-    test_suite_id="8b7ba080-8d14-42d2-9250-ec0edb96abd7",
     page=1,
     page_size=5,
     total_count=1,
@@ -384,7 +383,6 @@ MOCK_RUNS_RESPONSE_JSON = {
             "updated_at": "2023-06-22T21:56:03.346141",
         }
     ],
-    "test_suite_id": "8b7ba080-8d14-42d2-9250-ec0edb96abd7",
     "total_count": 1,
     "total_pages": 1,
 }


### PR DESCRIPTION
remove `test_suite_id` from runs response for consistency with REST API