### PR TITLE
add environment variable for toggling remote vs local storage

### DIFF
--- a/arthur_bench/client/rest/bench/client.py
+++ b/arthur_bench/client/rest/bench/client.py
@@ -300,7 +300,7 @@ class ArthurBenchClient(BenchClient):
             self.http_client.post(
                 "/bench/scoring/hallucination",
                 json=json_body.json(),
-                validation_response_code=HTTPStatus.CREATED,
+                validation_response_code=HTTPStatus.OK,
             ),
         )
         return HallucinationScoreResponse(**parsed_resp)

--- a/arthur_bench/client/utils.py
+++ b/arthur_bench/client/utils.py
@@ -8,10 +8,10 @@ from arthur_bench.client.rest import ArthurClient
 
 def _get_bench_client() -> BenchClient:
     client: BenchClient
-    url = os.getenv("ARTHUR_API_URL")
-    if url:  # if remote url is specified use remote client
+    use_remote = os.getenv("ARTHUR_BENCH_AUTOLOG")
+    if use_remote:  # if remote url is specified use remote client
         try:
-            client = ArthurClient(url=url).bench
+            client = ArthurClient().bench
         except (UserValueError, MissingParameterError) as e:
             raise UserValueError(
                 f"You must provide authentication when using remote url: {e}"

--- a/arthur_bench/scoring/hallucination.py
+++ b/arthur_bench/scoring/hallucination.py
@@ -44,6 +44,7 @@ class Hallucination(Scorer):
                 response=candidate_batch[i], context=context_batch[i]
             )
             response = self.client.bench.score_hallucination(request)
-            score = float(response["hallucination"])
+            # score 0 if there is a hallucination, 1 if no hallucination found
+            score = float(not response.hallucination)
             res.append(score)
         return res

--- a/tests/scorers/test_hallucination.py
+++ b/tests/scorers/test_hallucination.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 from tests.helpers import get_mock_client
 from arthur_bench.scoring.hallucination import Hallucination
+from arthur_bench.models.scoring import HallucinationScoreResponse
 from tests.fixtures.mock_data import MOCK_SUMMARY_DATA
 
 
@@ -11,10 +12,9 @@ def mock_client():
     mock_client = get_mock_client()
     mock_client.bench = Mock()
     mock_client.bench.score_hallucination = Mock()
-    mock_client.bench.score_hallucination.return_value = {
-        "hallucination": "0",
-        "reason": "this is the reason",
-    }
+    mock_client.bench.score_hallucination.return_value = HallucinationScoreResponse(
+        hallucination=False, reason="this is the reason"
+    )
     return mock_client
 
 
@@ -42,4 +42,4 @@ def test_run_batch(mock_client):
             )
 
         # assert correct return values for mock responses
-        assert result == [0.0] * len(MOCK_SUMMARY_DATA)
+        assert result == [1.0] * len(MOCK_SUMMARY_DATA)

--- a/tests/scorers/test_summary_quality.py
+++ b/tests/scorers/test_summary_quality.py
@@ -1,16 +1,8 @@
 import pytest
 from unittest.mock import Mock, patch
 
-from langchain.llms.fake import FakeListLLM
 from tests.fixtures.mock_data import MOCK_SUMMARY_DATA
 from arthur_bench.scoring.summary_quality import SummaryQuality
-
-
-@pytest.fixture
-def mock_llm():
-    mock_llm = Mock()
-    mock_llm.return_value = FakeListLLM
-    return mock_llm
 
 
 @pytest.fixture
@@ -21,33 +13,32 @@ def mock_llm_chain():
 
 
 # Test the run_batch method
-def test_run_batch(mock_llm_chain, mock_llm):
+def test_run_batch(mock_llm_chain):
     with patch(
         "arthur_bench.scoring.summary_quality.LLMChain", return_value=mock_llm_chain
     ):
-        with patch("arthur_bench.scoring.summary_quality.ChatOpenAI", mock_llm):
-            # create summary quality scoring method
-            summary_quality = SummaryQuality()
+        # create summary quality scoring method
+        summary_quality = SummaryQuality()
 
-            # get run batch result
-            result = summary_quality.run_batch(
-                MOCK_SUMMARY_DATA["candidate_summary"],
-                MOCK_SUMMARY_DATA["summary"],
-                input_text_batch=MOCK_SUMMARY_DATA["source"],
+        # get run batch result
+        result = summary_quality.run_batch(
+            MOCK_SUMMARY_DATA["candidate_summary"],
+            MOCK_SUMMARY_DATA["summary"],
+            input_text_batch=MOCK_SUMMARY_DATA["source"],
+        )
+
+        # assert LLMChain called with correct parameters
+        for i in range(len(MOCK_SUMMARY_DATA)):
+            mock_llm_chain.assert_any_call(
+                {
+                    "text": MOCK_SUMMARY_DATA["source"][i],
+                    "summary_A": MOCK_SUMMARY_DATA["summary"][i],
+                    "summary_B": MOCK_SUMMARY_DATA["candidate_summary"][i],
+                }
             )
 
-            # assert LLMChain called with correct parameters
-            for i in range(len(MOCK_SUMMARY_DATA)):
-                mock_llm_chain.assert_any_call(
-                    {
-                        "text": MOCK_SUMMARY_DATA["source"][i],
-                        "summary_A": MOCK_SUMMARY_DATA["summary"][i],
-                        "summary_B": MOCK_SUMMARY_DATA["candidate_summary"][i],
-                    }
-                )
-
-            # assert correct return values for mock LLMChain outputs
-            assert result == [0.0] * len(MOCK_SUMMARY_DATA)
+        # assert correct return values for mock LLMChain outputs
+        assert result == [0.0] * len(MOCK_SUMMARY_DATA)
 
 
 # Test the run_batch method with different return values from LLMChain
@@ -60,17 +51,14 @@ def test_run_batch(mock_llm_chain, mock_llm):
         ({"text": "invalid"}, [-1.0]),
     ],
 )
-def test_run_batch_with_different_llm_returns(
-    llm_return, expected, mock_llm_chain, mock_llm
-):
+def test_run_batch_with_different_llm_returns(llm_return, expected, mock_llm_chain):
     mock_llm_chain.return_value = llm_return
     with patch(
         "arthur_bench.scoring.summary_quality.LLMChain", return_value=mock_llm_chain
     ):
-        with patch("arthur_bench.scoring.summary_quality.ChatOpenAI", mock_llm):
-            summary_quality = SummaryQuality()
-            result = summary_quality.run_batch(["candidate"], ["reference"], ["input"])
-            mock_llm_chain.assert_called_once_with(
-                {"text": "input", "summary_A": "reference", "summary_B": "candidate"}
-            )
-            assert result == expected
+        summary_quality = SummaryQuality()
+        result = summary_quality.run_batch(["candidate"], ["reference"], ["input"])
+        mock_llm_chain.assert_called_once_with(
+            {"text": "input", "summary_A": "reference", "summary_B": "candidate"}
+        )
+        assert result == expected

--- a/tests/scorers/test_summary_quality.py
+++ b/tests/scorers/test_summary_quality.py
@@ -1,4 +1,6 @@
+import os
 import pytest
+from unittest import mock
 from unittest.mock import Mock, patch
 
 from tests.fixtures.mock_data import MOCK_SUMMARY_DATA
@@ -13,6 +15,7 @@ def mock_llm_chain():
 
 
 # Test the run_batch method
+@mock.patch.dict(os.environ, {"OPENAI_API_KEY": "MOCK_API_KEY"})
 def test_run_batch(mock_llm_chain):
     with patch(
         "arthur_bench.scoring.summary_quality.LLMChain", return_value=mock_llm_chain
@@ -51,6 +54,7 @@ def test_run_batch(mock_llm_chain):
         ({"text": "invalid"}, [-1.0]),
     ],
 )
+@mock.patch.dict(os.environ, {"OPENAI_API_KEY": "MOCK_API_KEY"})
 def test_run_batch_with_different_llm_returns(llm_return, expected, mock_llm_chain):
     mock_llm_chain.return_value = llm_return
     with patch(


### PR DESCRIPTION
the `ARTHUR_API_URL` was overloaded to both specify a URL and indicate whether remote or local client should be used. with the addition of the remote hallucination check, this would prevent users from using the hallucination scorer in local mode, so adding a new env variable `ARTHUR_BENCH_AUTOLOG` to decouple.

also cleaned up some messy tests. testing changes are completely unrelated to changes made in this PR