### PR TITLE
Added Project.urls to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,11 @@ docs = [
 [project.scripts]
 bench = "arthur_bench.server.run_server:run"
 
+[project.urls]
+Homepage = "https://www.arthur.ai/arthur-bench"
+Documentation = "https://bench.readthedocs.io/"
+Repository = "https://github.com/arthur-ai/bench"
+
 [metadata]
 url = 'http://arthur.ai'
 


### PR DESCRIPTION
PyPI doesn't have the homepage, documentation link or repository for the project. This change should add all three urls to the PyPI page in the left column during the next PyPI build. 