### PR TITLE
Fix UI breaks when page is refreshed on non-root route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ include/
 arthur_bench/server/js/dist/*
 arthur_bench/server/js/node_modules/*
 arthur_bench/server/js/packages/*/node_modules/
+
+bench_runs
+*package-lock.json
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For bug fixes and feature requests, please file a Github issue.
 
 ## Package installation
 
-Install Bench to your python environment with optional dependencies for serving results locally (recommended):  
+Install Bench to your python environment with optional dependencies for serving results locally (recommended):
 `pip install 'arthur-bench[server]'`
 
 Alternatively, install Bench to your python environment with minimum dependencies:
@@ -31,9 +31,9 @@ To make sure you can run test suites in bench, you can run the following code sn
 ```python
 from arthur_bench.run.testsuite import TestSuite
 suite = TestSuite(
-    "bench_quickstart", 
+    "bench_quickstart",
     "exact_match",
-    input_text_list=["What year was FDR elected?", "What is the opposite of down?"], 
+    input_text_list=["What year was FDR elected?", "What is the opposite of down?"],
     reference_output_list=["1932", "up"]
 )
 suite.run("quickstart_run", candidate_output_list=["1932", "up is the opposite of down"])
@@ -55,3 +55,20 @@ bench
 Viewing examples in the bench UI will look something like this:
 <p align="center">
 <img src="docs/source/_static/img/Bench_UI_Screenshot.png" alt="Examples UI" width="1100"/>
+
+## Running Bench from source
+
+To launch Bench from source:
+
+1. Install the dependencies
+    * `pip install -e '.[server]'`
+2. Build the Front End
+    * `cd arthur_bench/server/js`
+    * `npm i`
+    * `npm run build`
+3. Launch the server
+    * `bench`
+
+Because the server was installed with `pip -e`, local changes will be picked up. However, the server will need to be restarted between
+changes in order for those changes to be picked up.
+

--- a/arthur_bench/server/run_server.py
+++ b/arthur_bench/server/run_server.py
@@ -6,10 +6,11 @@ from pathlib import Path
 import uuid
 from typing import Optional, Annotated, List, Union
 
+from .spa_static_files import SPAStaticFiles
+
 try:
     import uvicorn
     from fastapi import FastAPI, Request, HTTPException, Query
-    from fastapi.staticfiles import StaticFiles
     from fastapi.middleware.cors import CORSMiddleware
 
 
@@ -169,7 +170,7 @@ def test_run_results(
 
 if os.path.exists(FRONT_END_DIRECTORY):
     app.mount(
-        "/", StaticFiles(directory=FRONT_END_DIRECTORY, html=True), name="frontend"
+        "/", SPAStaticFiles(directory=FRONT_END_DIRECTORY, html=True), name="frontend"
     )
 else:
     logger.warning(

--- a/arthur_bench/server/spa_static_files.py
+++ b/arthur_bench/server/spa_static_files.py
@@ -22,7 +22,6 @@ class SPAStaticFiles(StaticFiles):
         try:
             return await super().get_response(path, scope)
         except starlette.middleware.exceptions.HTTPException as ex:
-            print(path)
             if ex.status_code == 404 and "bench" in path:
                 return await super().get_response("index.html", scope)
             else:

--- a/arthur_bench/server/spa_static_files.py
+++ b/arthur_bench/server/spa_static_files.py
@@ -1,0 +1,26 @@
+try:
+    import starlette
+    from starlette.staticfiles import StaticFiles
+except ImportError as e:
+    raise ImportError(
+        "Can't run Bench Server without server dependencies, to install run: "
+        "pip install arthur-bench[server]"
+    ) from e
+
+
+class SPAStaticFiles(StaticFiles):
+    """
+    Because the Bench UI uses React's DOM Routing library, users might reload their page at a different path than what
+    the UI is mounted on (eg: /). When this happens, FastAPI will try to reconcile the route to a file in the StaticFiles
+    directory, and because it doesn't exist will throw a 404. So instead, if we detect that a user is trying to load a
+    Bench page and gets a 404, we instead first redirect to the / so that the UI is loaded first before re-routing.
+    """
+    async def get_response(self, path: str, scope):
+        try:
+            return await super().get_response(path, scope)
+        except starlette.middleware.exceptions.HTTPException as ex:
+            print(path)
+            if ex.status_code == 404 and "bench" in path:
+                return await super().get_response("index.html", scope)
+            else:
+                raise ex

--- a/arthur_bench/server/spa_static_files.py
+++ b/arthur_bench/server/spa_static_files.py
@@ -10,11 +10,14 @@ except ImportError as e:
 
 class SPAStaticFiles(StaticFiles):
     """
-    Because the Bench UI uses React's DOM Routing library, users might reload their page at a different path than what
-    the UI is mounted on (eg: /). When this happens, FastAPI will try to reconcile the route to a file in the StaticFiles
-    directory, and because it doesn't exist will throw a 404. So instead, if we detect that a user is trying to load a
-    Bench page and gets a 404, we instead first redirect to the / so that the UI is loaded first before re-routing.
+    Because the Bench UI uses React's DOM Routing library, users might reload their page
+    at a different path than what the UI is mounted on (eg: /). When this happens,
+    FastAPI will try to reconcile the route to a file in the StaticFiles directory,
+    and because it doesn't exist will throw a 404. So instead, if we detect that a user
+    is trying to load a Bench page and gets a 404, we instead first redirect to the
+    / so that the UI is loaded first before re-routing.
     """
+
     async def get_response(self, path: str, scope):
         try:
             return await super().get_response(path, scope)


### PR DESCRIPTION
// Internal ticket BENCH-247

## Before this MR 

When refreshing a page after routing to a non-root route (eg: a specific test suite), the UI would break and show a JSONified 404 error. 

## After this MR 

Refreshing the page on a non-root route works as expected. 

