### PR TITLE
[BENCH-301] hallucination as scorer in docs

### DIFF
--- a/arthur_bench/scoring/hallucination.py
+++ b/arthur_bench/scoring/hallucination.py
@@ -8,9 +8,9 @@ from arthur_bench.models.scoring import HallucinationScoreRequest
 class Hallucination(Scorer):
     """
     Score each output against a context using Arthur's hosted hallucination checker
-    A score of 1.0 means the hallucination checker estimates the output is supported by
+    A score of 0.0 means the hallucination checker estimates the output is supported by
     the context
-    A score of 0.0 means the hallucination checker found information in the output
+    A score of 1.0 means the hallucination checker found information in the output
     unsupported by the context
     """
 
@@ -44,7 +44,6 @@ class Hallucination(Scorer):
                 response=candidate_batch[i], context=context_batch[i]
             )
             response = self.client.bench.score_hallucination(request)
-            # score 0 if there is a hallucination, 1 if no hallucination found
-            score = float(not response.hallucination)
+            score = float(response.hallucination)
             res.append(score)
         return res

--- a/docs/source/scoring.md
+++ b/docs/source/scoring.md
@@ -12,6 +12,7 @@ Here is a list of all the scorers available by default in Arthur Bench (listed a
 |-----------------------------------|-----|-----|-----|
 | BERT Score (`bertscore`)          | any |  Embedding-Based | Reference Output, Candidate Output|
 | Exact Match (`exact_match`)       | any | Lexicon-Based | Reference Output, Candidate Output|
+| Hallucination (`hallucination`)       | any | Prompt-Based | Candidate Output, Context|
 | Hedging Language (`hedging_language`)   | any | Embedding-Based | Candidate Output |
 | Python Unit Testing (`python_unit_testing`)   | Python Generation | Code Evaluator| Candidate Output, Unit Tests (see the [code eval guide](code_evaluation.md)) |
 | QA Correctness (`qa_correctness`) | Question-Answering| Prompt-Based | Input, Candidate Output, Context|
@@ -32,6 +33,10 @@ The QA correctness scorer evaluates the correctness of an answer, given a questi
 ### `summary_quality`
 
 The Summary Quality scorer evaluates a summary against its source text and a reference summary for comparison. It evaluates summaries on dimensions including relevance and syntax. Each row of the test run will receive a binary 0, indicating that the reference output was scored higher than the candidate output, or 1, indicating that the candidate output was scored higher than the reference output.
+
+### `hallucination`
+
+The Hallucination scorer takes a response and a context (e.g. in a RAG setting where context is used to ground an LLM’s responses) and identifies when information in the response is not substantiated by the context . The scorer breaks down the response into a list of claims and checks the claims against the context for support. This binary score is 0 if all claims are supported, and 1 otherwise.
 
 ## Embedding-Based Scorers
 

--- a/tests/scorers/test_hallucination.py
+++ b/tests/scorers/test_hallucination.py
@@ -42,4 +42,4 @@ def test_run_batch(mock_client):
             )
 
         # assert correct return values for mock responses
-        assert result == [1.0] * len(MOCK_SUMMARY_DATA)
+        assert result == [0.0] * len(MOCK_SUMMARY_DATA)


### PR DESCRIPTION
- Added hallucination with a decsription to our scoring guide: https://bench.readthedocs.io/en/latest/scoring.html
- Updated the scorer code so that 1.0 = hallucination, 0.0 = no hallucination (used to be reversed)