### PR TITLE
Small fix: broken link for TestSuite SDK in the docs

### DIFF
--- a/docs/source/creating_test_suites.md
+++ b/docs/source/creating_test_suites.md
@@ -22,7 +22,7 @@ You can provide data for your `TestSuite` via the following options, each of whi
 3. CSV file
 4. HuggingFace Dataset
 
-To see the exact specifications for the `TestSuite` class, visit our [SDK docs](https://bench.readthedocs.io/en/latest/testsuite.html#arthur_bench.run.testsuite.TestSuite).
+To see the exact specifications for the `TestSuite` class, visit our [SDK docs](https://bench.readthedocs.io/en/latest/sdk/arthur_bench.run.html#arthur_bench.run.testsuite.TestSuite).
 
 ### `List[str]` -> `TestSuite`
 


### PR DESCRIPTION
I noticed the link was broken, and I believe I found what it should be pointing to... Hopefully, it is the right link!