### PR TITLE
Parameters for hedging language are now editable

### DIFF
--- a/arthur_bench/scoring/hedging_language.py
+++ b/arthur_bench/scoring/hedging_language.py
@@ -21,7 +21,7 @@ class HedgingLanguage(Scorer):
 
     def __init__(self, model_type=DEFAULT_MODEL, hedging_language=DEFAULT_HEDGE):
         """
-        Hedging Language score implementation. 
+        Hedging Language score implementation.
 
         :param model_type: the underlying language model to extract embeddings from
         :param hedging_language: reference hedging language used by an llm

--- a/arthur_bench/scoring/hedging_language.py
+++ b/arthur_bench/scoring/hedging_language.py
@@ -5,7 +5,6 @@ from arthur_bench.scoring.utils import suppress_warnings
 
 DEFAULT_MODEL = "microsoft/deberta-v3-base"
 
-# [TODO] need to make these editable by user
 DEFAULT_HEDGE = (
     "As an AI language model, I don't have personal opinions, emotions, or beliefs."
 )
@@ -20,6 +19,18 @@ class HedgingLanguage(Scorer):
     model output.
     """
 
+    def __init__(self, model_type=DEFAULT_MODEL, hedging_language=DEFAULT_HEDGE):
+        """
+        Hedging Language score implementation. 
+
+        :param model_type: the underlying language model to extract embeddings from
+        :param hedging_language: reference hedging language used by an llm
+        """
+        self.hedging_language = hedging_language
+
+        with suppress_warnings("transformers"):
+            self.scorer = BERTScorer(lang="en", model_type=model_type)
+
     @staticmethod
     def name() -> str:
         return "hedging_language"
@@ -27,10 +38,6 @@ class HedgingLanguage(Scorer):
     @staticmethod
     def requires_reference() -> bool:
         return False
-
-    def __init__(self):
-        with suppress_warnings("transformers"):
-            self.scorer = BERTScorer(lang="en", model_type=DEFAULT_MODEL)
 
     def to_dict(self, warn=False):
         return {"model_type": self.scorer.model_type}
@@ -43,7 +50,7 @@ class HedgingLanguage(Scorer):
         context_batch: Optional[List[str]] = None,
     ) -> List[float]:
         # convert reference hedge to list
-        reference_batch = [DEFAULT_HEDGE] * len(candidate_batch)
+        reference_batch = [self.hedging_language] * len(candidate_batch)
 
         # get precision, recall, and F1 score from bert_score package
         p, r, f = self.scorer.score(candidate_batch, reference_batch, verbose=False)


### PR DESCRIPTION
Adding `DEFAULT_MODEL` and `DEFAULT_HEDGE` as parameters. 

* I ran `pytest` successfully 
```
75 passed, 4 warnings in 17.64s
```
* ran `black` on the edited file 