### PR TITLE
LLM-818 - Add run id filter to summary endpoint

### DIFF
--- a/arthur_bench/client/bench_client.py
+++ b/arthur_bench/client/bench_client.py
@@ -123,7 +123,7 @@ class BenchClient(ABC):
     def get_summary_statistics(
         self,
         test_suite_id: str,
-        run_id: Optional[str] = None,
+        run_ids: Optional[list[str]] = None,
         page: int = 1,
         page_size: int = 5,
     ) -> TestSuiteSummary:

--- a/arthur_bench/client/local/client.py
+++ b/arthur_bench/client/local/client.py
@@ -410,9 +410,14 @@ class LocalBenchClient(BenchClient):
         run_files = glob.glob(f"{self.root_dir}/{test_suite_name}/*/run.json")
 
         if run_ids:
-            run_id_to_file_dict = {file.split("/")[-2]: file for file in run_files}
+            run_name_to_file_dict = {file.split("/")[-2]: file for file in run_files}
+            run_names = [
+                self._get_run_name_from_id(test_suite_name, id) for id in run_ids
+            ]
             filtered_run_files = {
-                k: run_id_to_file_dict[k] for k in run_ids if k in run_id_to_file_dict
+                k: run_name_to_file_dict[k]
+                for k in run_names
+                if k in run_name_to_file_dict
             }
             run_files = filtered_run_files.values()
 

--- a/arthur_bench/client/local/client.py
+++ b/arthur_bench/client/local/client.py
@@ -419,7 +419,7 @@ class LocalBenchClient(BenchClient):
                 for k in run_names
                 if k in run_name_to_file_dict
             }
-            run_files = filtered_run_files.values()
+            run_files = list(filtered_run_files.values())
 
         for f in run_files:
             run_obj = PaginatedRun.parse_file(f)

--- a/arthur_bench/client/local/client.py
+++ b/arthur_bench/client/local/client.py
@@ -404,6 +404,8 @@ class LocalBenchClient(BenchClient):
         if test_suite_name is None:
             raise NotFoundError(f"no test suite with id {test_suite_id}")
 
+        suite = self.get_test_suite(test_suite_id)
+
         runs: list[SummaryItem] = []
         run_files = glob.glob(f"{self.root_dir}/{test_suite_name}/*/run.json")
         for f in run_files:
@@ -416,7 +418,7 @@ class LocalBenchClient(BenchClient):
         pagination = _paginate(runs, page, page_size, sort_key="avg_score")
         paginated_summary = TestSuiteSummary(
             summary=runs,
-            num_test_cases=len(run_obj.test_cases),
+            num_test_cases=len(suite.test_cases),
             page_size=pagination.page_size,
             page=pagination.page,
             total_pages=pagination.total_pages,

--- a/arthur_bench/client/local/client.py
+++ b/arthur_bench/client/local/client.py
@@ -408,12 +408,17 @@ class LocalBenchClient(BenchClient):
 
         runs: list[SummaryItem] = []
         run_files = glob.glob(f"{self.root_dir}/{test_suite_name}/*/run.json")
+
+        if run_ids:
+            run_id_to_file_dict = {file.split("/")[-2]: file for file in run_files}
+            filtered_run_files = {
+                k: run_id_to_file_dict[k] for k in run_ids if k in run_id_to_file_dict
+            }
+            run_files = filtered_run_files.values()
+
         for f in run_files:
             run_obj = PaginatedRun.parse_file(f)
             runs.append(_summarize_run(run=run_obj))
-
-        if run_ids:
-            runs = [run for run in runs if str(run.id) in run_ids]
 
         pagination = _paginate(runs, page, page_size, sort_key="avg_score")
         paginated_summary = TestSuiteSummary(

--- a/arthur_bench/client/local/client.py
+++ b/arthur_bench/client/local/client.py
@@ -409,10 +409,10 @@ class LocalBenchClient(BenchClient):
         for f in run_files:
             run_obj = PaginatedRun.parse_file(f)
             runs.append(_summarize_run(run=run_obj))
-        
-        if run_ids: 
-            runs= [run for run in runs if str(run.id) in run_ids]
- 
+
+        if run_ids:
+            runs = [run for run in runs if str(run.id) in run_ids]
+
         pagination = _paginate(runs, page, page_size, sort_key="avg_score")
         paginated_summary = TestSuiteSummary(
             summary=runs,

--- a/arthur_bench/client/rest/bench/client.py
+++ b/arthur_bench/client/rest/bench/client.py
@@ -137,7 +137,7 @@ class ArthurBenchClient(BenchClient):
     def get_summary_statistics(
         self,
         test_suite_id: str,
-        run_id: Optional[str] = None,
+        run_ids: Optional[list[str]] = None,
         page: int = 1,
         page_size: int = 5,
     ) -> TestSuiteSummary:
@@ -153,8 +153,8 @@ class ArthurBenchClient(BenchClient):
         """
 
         params = {}
-        if run_id is not None:
-            params["run_id"] = run_id
+        if run_ids is not None:
+            params["run_ids"] = run_ids
         if page is not None:
             params["page"] = page  # type: ignore
         if page_size is not None:

--- a/arthur_bench/server/run_server.py
+++ b/arthur_bench/server/run_server.py
@@ -130,7 +130,7 @@ def test_suite_summary(
     test_suite_id: uuid.UUID,
     page: int = 1,
     page_size: int = 5,
-    run_ids: Annotated[list[uuid.UUID], Query()] = None,
+    run_ids: Annotated[Optional[list[uuid.UUID]], Query()] = None,
 ):
     client = request.app.state.client
     try:

--- a/arthur_bench/server/run_server.py
+++ b/arthur_bench/server/run_server.py
@@ -130,7 +130,7 @@ def test_suite_summary(
     test_suite_id: uuid.UUID,
     page: int = 1,
     page_size: int = 5,
-    run_id: Optional[uuid.UUID] = None,
+    run_ids: Annotated[list[uuid.UUID], Query()] = None,
 ):
     client = request.app.state.client
     try:
@@ -138,7 +138,7 @@ def test_suite_summary(
             test_suite_id=str(test_suite_id),
             page=page,
             page_size=page_size,
-            run_id=str(run_id) if run_id is not None else None,
+            run_ids=[str(run_id) for run_id in run_ids] if run_ids else None,
         )
     except NotFoundError as e:
         return HTTPException(status_code=404, detail=str(e))

--- a/tests/client/test_local_client.py
+++ b/tests/client/test_local_client.py
@@ -181,11 +181,13 @@ def test_check_run_exists(bench_temp_dir_with_runs):
     assert client.check_run_exists(SUITE_EXISTS, "invalid run") == False
 
 
-def get_summary_statistics(bench_temp_dir_with_runs):
+def test_get_summary_statistics(bench_temp_dir_with_runs):
     with mock.patch(
-        "arthur_bench.client.local.client.LocalBenchClient._summarize_run",
+        "arthur_bench.client.local.client._summarize_run",
         mock_summarize,
     ):
         client = LocalBenchClient(bench_temp_dir_with_runs)
         resp = client.get_summary_statistics(SUITE_EXISTS)
         assert resp == MOCK_SUMMARY_RESPONSE
+        resp = client.get_summary_statistics(SUITE_EXISTS, run_ids=["does_not_exist"])
+        assert len(resp.summary) == 0


### PR DESCRIPTION
This change changes the runs/summary endpoint. Previously it queried all runs and optionally added an extra specific one. This change adds an optional filter that allows a user to pull multiple specific ones. This is not used in conjunction with the normal query function but is a hard filter. This is more in line with standard REST practices of using filters on query endpoints: https://www.moesif.com/blog/technical/api-design/REST-API-Design-Filtering-Sorting-and-Pagination/