### PR TITLE
add sort param to get test run by id

### DIFF
--- a/arthur_bench/client/bench_client.py
+++ b/arthur_bench/client/bench_client.py
@@ -10,6 +10,11 @@ from arthur_bench.models.models import (
     TestSuiteRequest,
     PaginatedTestSuite,
     TestSuiteSummary,
+    TestCaseSortEnum,
+    CommonSortEnum,
+    TestSuiteSortEnum,
+    PaginationRunSortEnum,
+    PaginationSuiteSortEnum,
 )
 
 from arthur_bench.exceptions import ArthurInternalError
@@ -26,7 +31,7 @@ class BenchClient(ABC):
     def get_test_suites(
         self,
         name: Optional[str] = None,
-        sort: Optional[str] = None,
+        sort: PaginationSuiteSortEnum = TestSuiteSortEnum.LAST_RUNTIME_ASC,
         scoring_method: Optional[List[str]] = None,
         page: int = 1,
         page_size: int = 5,
@@ -72,7 +77,7 @@ class BenchClient(ABC):
     def get_runs_for_test_suite(
         self,
         test_suite_id: str,
-        sort: Optional[str] = None,
+        sort: PaginationRunSortEnum = CommonSortEnum.CREATED_AT_ASC,
         page: int = 1,
         page_size: int = 5,
     ) -> PaginatedRuns:
@@ -107,7 +112,7 @@ class BenchClient(ABC):
         test_run_id: str,
         page: int = 1,
         page_size: int = 5,
-        sort: Optional[bool] = None,
+        sort: TestCaseSortEnum = TestCaseSortEnum.SCORE_ASC,
     ) -> PaginatedRun:
         """
         Get a test run by id.
@@ -116,6 +121,7 @@ class BenchClient(ABC):
         :param test_run_id: uuid of the test run
         :param page: the page to fetch, pagination refers to the test cases
         :param page_size: page size to fetch, pagination refers to the test cases
+        :param sort: sort key to sort the retrieved results
         """
         raise NotImplementedError
 

--- a/arthur_bench/client/local/client.py
+++ b/arthur_bench/client/local/client.py
@@ -32,6 +32,13 @@ from arthur_bench.models.models import (
     RunResult,
     ScoringMethod,
     ScorerOutputType,
+    PaginationSuiteSortEnum,
+    PaginationRunSortEnum,
+    PaginationSortEnum,
+    CommonSortEnum,
+    TestCaseSortEnum,
+    TestRunSortEnum,
+    TestSuiteSortEnum,
 )
 
 from arthur_bench.utils.loaders import load_suite_from_json, get_file_extension
@@ -48,20 +55,21 @@ DEFAULT_PAGE_SIZE = 5
 NUM_BINS = 20
 
 SORT_QUERY_TO_FUNC = {
-    "last_run_time": lambda x: x.last_run_time
+    TestSuiteSortEnum.LAST_RUNTIME_ASC: lambda x: x.last_run_time
     if x.last_run_time is not None
     else x.created_at,
-    "name": lambda x: x.name,
-    "created_at": lambda x: x.created_at,
-    "avg_score": lambda x: x.avg_score,
-    "-last_run_time": lambda x: x.last_run_time
+    CommonSortEnum.NAME_ASC: lambda x: x.name,
+    CommonSortEnum.CREATED_AT_ASC: lambda x: x.created_at,
+    TestRunSortEnum.AVG_SCORE_ASC: lambda x: x.avg_score,
+    TestSuiteSortEnum.LAST_RUNTIME_DESC: lambda x: x.last_run_time
     if x.last_run_time is not None
     else x.created_at,
-    "-name": lambda x: x.name,
-    "-created_at": lambda x: x.created_at,
-    "-avg_score": lambda x: x.avg_score,
-    "score": lambda x: x.score,
-    "id": lambda x: x.id,
+    CommonSortEnum.NAME_DESC: lambda x: x.name,
+    CommonSortEnum.CREATED_AT_DESC: lambda x: x.created_at,
+    TestRunSortEnum.AVG_SCORE_DESC: lambda x: x.avg_score,
+    TestCaseSortEnum.SCORE_ASC: lambda x: x.score,
+    TestCaseSortEnum.SCORE_DESC: lambda x: x.score,
+    TestCaseSortEnum.ID_ASC: lambda x: x.id,
 }
 
 
@@ -281,7 +289,7 @@ class LocalBenchClient(BenchClient):
     def get_test_suites(
         self,
         name: Optional[str] = None,
-        sort: Optional[str] = None,
+        sort: PaginationSuiteSortEnum = TestSuiteSortEnum.LAST_RUNTIME_ASC,
         scoring_method: Optional[List[str]] = None,
         page: int = 1,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -338,9 +346,6 @@ class LocalBenchClient(BenchClient):
                     )
                 )
 
-        # default sort by last run time
-        if sort is None:
-            sort = "last_run_time"
         paginate = _paginate(suites, page=page, page_size=page_size, sort_key=sort)
         return PaginatedTestSuites(
             test_suites=paginate.sorted_pages[paginate.start : paginate.end],
@@ -400,7 +405,7 @@ class LocalBenchClient(BenchClient):
     def get_runs_for_test_suite(
         self,
         test_suite_id: str,
-        sort: Optional[str] = None,
+        sort: PaginationRunSortEnum = CommonSortEnum.CREATED_AT_ASC,
         page: int = 1,
         page_size: int = DEFAULT_PAGE_SIZE,
     ) -> PaginatedRuns:
@@ -415,9 +420,6 @@ class LocalBenchClient(BenchClient):
             avg_score = np.mean([o.score for o in run_obj.test_cases])
             run_resp = TestRunMetadata(**run_obj.dict(), avg_score=float(avg_score))
             runs.append(run_resp)
-
-        if sort is None:
-            sort = "created_at"
 
         pagination = _paginate(runs, page, page_size, sort_key=sort)
 
@@ -485,7 +487,7 @@ class LocalBenchClient(BenchClient):
         test_run_id: str,
         page: int = 1,
         page_size: int = DEFAULT_PAGE_SIZE,
-        sort: Optional[bool] = True,
+        sort: TestCaseSortEnum = TestCaseSortEnum.SCORE_ASC,
     ) -> PaginatedRun:
         test_suite_name = self._get_suite_name_from_id(test_suite_id)
         if test_suite_name is None:
@@ -521,7 +523,8 @@ class LocalBenchClient(BenchClient):
             cases = []
 
         run_results = [RunResult.parse_obj(r) for r in cases]
-        pagination = _paginate(run_results, page, page_size, sort_key="score")
+
+        pagination = _paginate(run_results, page, page_size, sort_key=sort)
         return PaginatedRun(
             id=uuid.UUID(test_run_id),
             name=run_name,

--- a/arthur_bench/client/rest/bench/client.py
+++ b/arthur_bench/client/rest/bench/client.py
@@ -14,6 +14,11 @@ from arthur_bench.models.models import (
     PaginatedTestSuite,
     TestSuiteSummary,
     CreateRunResponse,
+    TestCaseSortEnum,
+    CommonSortEnum,
+    TestSuiteSortEnum,
+    PaginationRunSortEnum,
+    PaginationSuiteSortEnum,
 )
 
 from arthur_bench.models.scoring import (
@@ -43,7 +48,7 @@ class ArthurBenchClient(BenchClient):
     def get_test_suites(
         self,
         name: Optional[str] = None,
-        sort: Optional[str] = None,
+        sort: PaginationSuiteSortEnum = TestSuiteSortEnum.LAST_RUNTIME_ASC,
         scoring_method: Optional[List[str]] = None,
         page: int = 1,
         page_size: int = 5,
@@ -177,7 +182,7 @@ class ArthurBenchClient(BenchClient):
     def get_runs_for_test_suite(
         self,
         test_suite_id: str,
-        sort: Optional[str] = None,
+        sort: PaginationRunSortEnum = CommonSortEnum.CREATED_AT_ASC,
         page: int = 1,
         page_size: int = 5,
     ) -> PaginatedRuns:
@@ -236,7 +241,7 @@ class ArthurBenchClient(BenchClient):
         test_run_id: str,
         page: int = 1,
         page_size: int = 5,
-        sort: Optional[bool] = None,
+        sort: TestCaseSortEnum = TestCaseSortEnum.SCORE_ASC,
     ) -> PaginatedRun:
         """
         Get a test run with input, output, and reference data
@@ -245,7 +250,7 @@ class ArthurBenchClient(BenchClient):
         :param test_run_id:
         :param page:
         :param page_size:
-        :param sort:
+        :param sort: sort key to sort the retrieved results
         """
 
         params = {}
@@ -254,7 +259,7 @@ class ArthurBenchClient(BenchClient):
         if page_size is not None:
             params["page_size"] = page_size  # type: ignore
         if sort is not None:
-            params["sort"] = sort
+            params["sort"] = sort  # type: ignore
 
         parsed_resp = cast(
             Dict,

--- a/arthur_bench/models/models.py
+++ b/arthur_bench/models/models.py
@@ -80,6 +80,38 @@ class ScoringMethod(BaseModel):
 # REQUESTS
 
 
+class CommonSortEnum(str, Enum):
+    NAME_ASC = "name"
+    NAME_DESC = "-name"
+    CREATED_AT_ASC = "created_at"
+    CREATED_AT_DESC = "-created_at"
+
+
+class TestSuiteSortEnum(str, Enum):
+    LAST_RUNTIME_ASC = "last_run_time"
+    LAST_RUNTIME_DESC = "-last_run_time"
+
+
+class TestRunSortEnum(str, Enum):
+    AVG_SCORE_ASC = "avg_score"
+    AVG_SCORE_DESC = "-avg_score"
+
+
+class TestCaseSortEnum(str, Enum):
+    ID_ASC = "id"
+    SCORE_ASC = "score"
+    SCORE_DESC = "-score"
+
+
+PaginationSuiteSortEnum = Union[CommonSortEnum, TestSuiteSortEnum]
+
+PaginationRunSortEnum = Union[CommonSortEnum, TestRunSortEnum]
+
+PaginationSortEnum = Union[
+    TestCaseSortEnum, PaginationSuiteSortEnum, PaginationRunSortEnum
+]
+
+
 class TestCaseRequest(BaseModel):
     """
     An input, reference output pair.

--- a/arthur_bench/server/run_server.py
+++ b/arthur_bench/server/run_server.py
@@ -22,6 +22,13 @@ except ImportError as e:
 
 from arthur_bench.client.local.client import LocalBenchClient
 from arthur_bench.exceptions import NotFoundError
+from arthur_bench.models.models import (
+    PaginationSuiteSortEnum,
+    PaginationRunSortEnum,
+    TestCaseSortEnum,
+    CommonSortEnum,
+    TestSuiteSortEnum,
+)
 from arthur_bench.telemetry.telemetry import send_event, set_track_usage_data
 from arthur_bench.telemetry.config import get_or_persist_id, persist_usage_data
 
@@ -48,7 +55,9 @@ def test_suites(
     request: Request,
     page: int = 1,
     page_size: int = 5,
-    sort: Optional[str] = None,
+    sort: Annotated[
+        Optional[PaginationSuiteSortEnum], Query()
+    ] = TestSuiteSortEnum.LAST_RUNTIME_ASC,
     scoring_method: Annotated[Union[List[str], None], Query()] = None,
     name: Optional[str] = None,
 ):
@@ -97,7 +106,9 @@ def test_runs(
     test_suite_id: uuid.UUID,
     page: int = 1,
     page_size: int = 5,
-    sort: Optional[str] = None,
+    sort: Annotated[
+        Optional[PaginationRunSortEnum], Query()
+    ] = CommonSortEnum.CREATED_AT_ASC,
 ):
     client = request.app.state.client
     try:
@@ -152,6 +163,7 @@ def test_run_results(
     run_id: uuid.UUID,
     page: int = 1,
     page_size: int = 5,
+    sort: Annotated[Optional[TestCaseSortEnum], Query()] = TestCaseSortEnum.SCORE_ASC,
 ):
     client = request.app.state.client
 
@@ -161,6 +173,7 @@ def test_run_results(
             test_run_id=str(run_id),
             page=page,
             page_size=page_size,
+            sort=sort,
         ).json(by_alias=True)
     except NotFoundError as e:
         return HTTPException(status_code=404, detail=str(e))

--- a/tests/client/test_rest_client.py
+++ b/tests/client/test_rest_client.py
@@ -4,6 +4,11 @@ from http import HTTPStatus
 from unittest import mock
 from arthur_bench.client.http.requests import HTTPClient
 from arthur_bench.client.rest.bench.client import ArthurBenchClient
+from arthur_bench.models.models import (
+    TestSuiteSortEnum,
+    CommonSortEnum,
+    TestCaseSortEnum,
+)
 from tests.fixtures.mock_requests import (
     MOCK_SUITE,
     MOCK_SUITE_JSON,
@@ -28,7 +33,11 @@ def test_get_test_suites(mock_rest_client):
         _ = mock_rest_client.get_test_suites()
         mock_rest_client.http_client.get.assert_called_once_with(
             "/bench/test_suites",
-            params={"page": 1, "page_size": 5},
+            params={
+                "page": 1,
+                "page_size": 5,
+                "sort": TestSuiteSortEnum.LAST_RUNTIME_ASC,
+            },
             validation_response_code=HTTPStatus.OK,
         )
 
@@ -71,7 +80,7 @@ def test_get_runs(mock_rest_client):
         _ = mock_rest_client.get_runs_for_test_suite(test_suite_id)
         mock_rest_client.http_client.get.assert_called_once_with(
             f"/bench/test_suites/{test_suite_id}/runs",
-            params={"page": 1, "page_size": 5},
+            params={"page": 1, "page_size": 5, "sort": CommonSortEnum.CREATED_AT_ASC},
             validation_response_code=HTTPStatus.OK,
         )
 
@@ -83,7 +92,7 @@ def test_get_run_by_id(mock_rest_client):
         _ = mock_rest_client.get_test_run(test_suite_id, test_run_id)
         mock_rest_client.http_client.get.assert_called_once_with(
             f"/bench/test_suites/{test_suite_id}/runs/{test_run_id}",
-            params={"page": 1, "page_size": 5},
+            params={"page": 1, "page_size": 5, "sort": TestCaseSortEnum.SCORE_ASC},
             validation_response_code=HTTPStatus.OK,
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from arthur_bench.server.run_server import app
+from arthur_bench.models.models import TestSuiteSortEnum
 from tests.helpers import get_mock_client
 from tests.fixtures.mock_responses import (
     MOCK_SUITES_JSON,
@@ -39,7 +40,7 @@ def test_get_test_suites_with_filters(mock_client):
     mock_client.app.state.client.get_test_suites.assert_called_once_with(
         page=1,
         page_size=5,
-        sort=None,
+        sort=TestSuiteSortEnum.LAST_RUNTIME_ASC,
         scoring_method=["bertscore", "custom"],
         name=None,
     )


### PR DESCRIPTION
- add a sort param to `.../runs/{run_id}` to allow specifying `sort=id`. The alternative is `sort=score`. This is necessary to ensure that run data can be returned in the same order during side by side comparison
- refactor sort parameter code across client and server to use enums and fastapi annotations to validate sort parameters