### PR TITLE
remove duckdb from local client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    'duckdb~=0.8.1',
     'evaluate~=0.4.0',
     'openai==0.27.0',
     'pandas~=2.0.1',


### PR DESCRIPTION
Duckdb is throwing errors executing the multiple fetches necessary for test run comparisons. This is the only remaining endpoint still using duckdb so removing it as a dependency