### PR TITLE
Add demo scoring Bedrock models for Summarization

### DIFF
--- a/examples/bedrock_client/client.py
+++ b/examples/bedrock_client/client.py
@@ -1,0 +1,79 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Helper utilities for working with Amazon Bedrock from Python notebooks"""
+# Python Built-Ins:
+import os
+from typing import Optional
+
+# External Dependencies:
+import boto3
+from botocore.config import Config
+
+
+def get_bedrock_client(
+    assumed_role: Optional[str] = None,
+    region: Optional[str] = None,
+    runtime: Optional[bool] = True,
+):
+    """Create a boto3 client for Amazon Bedrock, with optional configuration overrides
+
+    Parameters
+    ----------
+    assumed_role :
+        Optional ARN of an AWS IAM role to assume for calling the Bedrock service. If not
+        specified, the current active credentials will be used.
+    region :
+        Optional name of the AWS Region in which the service should be called (e.g. "us-east-1").
+        If not specified, AWS_REGION or AWS_DEFAULT_REGION environment variable will be used.
+    runtime :
+        Optional choice of getting different client to perform operations with the Amazon Bedrock service.
+    """
+    if region is None:
+        target_region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION"))
+    else:
+        target_region = region
+
+    print(f"Create new client\n  Using region: {target_region}")
+    session_kwargs = {"region_name": target_region}
+    client_kwargs = {**session_kwargs}
+
+    profile_name = os.environ.get("AWS_PROFILE")
+    if profile_name:
+        print(f"  Using profile: {profile_name}")
+        session_kwargs["profile_name"] = profile_name
+
+    retry_config = Config(
+        region_name=target_region,
+        retries={
+            "max_attempts": 10,
+            "mode": "standard",
+        },
+    )
+    session = boto3.Session(**session_kwargs)
+
+    if assumed_role:
+        print(f"  Using role: {assumed_role}", end='')
+        sts = session.client("sts")
+        response = sts.assume_role(
+            RoleArn=str(assumed_role),
+            RoleSessionName="langchain-llm-1"
+        )
+        print(" ... successful!")
+        client_kwargs["aws_access_key_id"] = response["Credentials"]["AccessKeyId"]
+        client_kwargs["aws_secret_access_key"] = response["Credentials"]["SecretAccessKey"]
+        client_kwargs["aws_session_token"] = response["Credentials"]["SessionToken"]
+
+    if runtime:
+        service_name='bedrock-runtime'
+    else:
+        service_name='bedrock'
+
+    bedrock_client = session.client(
+        service_name=service_name,
+        config=retry_config,
+        **client_kwargs
+    )
+
+    print("boto3 Bedrock client successfully created!")
+    print(bedrock_client._endpoint)
+    return bedrock_client

--- a/examples/elo.py
+++ b/examples/elo.py
@@ -1,0 +1,150 @@
+"""
+Created 5-18-17
+All of the classes for EloPy. The users should only interact with the Implementation class.
+@author - Hank Hang Kai Sheehan
+"""
+
+class Implementation:
+    """
+    A class that represents an implementation of the Elo Rating System
+    """
+
+    def __init__(self, base_rating=1000):
+        """
+        Runs at initialization of class object.
+        @param base_rating - The rating a new player would have
+        """
+        self.base_rating = base_rating
+        self.players = []
+
+    def __getPlayerList(self):
+        """
+        Returns this implementation's player list.
+        @return - the list of all player objects in the implementation.
+        """
+        return self.players
+
+    def getPlayer(self, name):
+        """
+        Returns the player in the implementation with the given name.
+        @param name - name of the player to return.
+        @return - the player with the given name.
+        """
+        for player in self.players:
+            if player.name == name:
+                return player
+        return None
+
+    def contains(self, name):
+        """
+        Returns true if this object contains a player with the given name.
+        Otherwise returns false.
+        @param name - name to check for.
+        """
+        for player in self.players:
+            if player.name == name:
+                return True
+        return False
+
+    def addPlayer(self, name, rating=None):
+        """
+        Adds a new player to the implementation.
+        @param name - The name to identify a specific player.
+        @param rating - The player's rating.
+        """
+        if rating == None:
+            rating = self.base_rating
+
+        self.players.append(_Player(name=name,rating=rating))
+
+    def removePlayer(self, name):
+        """
+        Adds a new player to the implementation.
+        @param name - The name to identify a specific player.
+        """
+        self.__getPlayerList().remove(self.getPlayer(name))
+
+
+    def recordMatch(self, name1, name2, winner=None, draw=False):
+        """
+        Should be called after a game is played.
+        @param name1 - name of the first player.
+        @param name2 - name of the second player.
+        """
+        player1 = self.getPlayer(name1)
+        player2 = self.getPlayer(name2)
+
+        expected1 = player1.compareRating(player2)
+        expected2 = player2.compareRating(player1)
+
+        k = len(self.__getPlayerList()) * 42
+
+        rating1 = player1.rating
+        rating2 = player2.rating
+
+        if draw:
+            score1 = 0.5
+            score2 = 0.5
+        elif winner == name1:
+            score1 = 1.0
+            score2 = 0.0
+        elif winner == name2:
+            score1 = 0.0
+            score2 = 1.0
+        else:
+            raise InputError('One of the names must be the winner or draw must be True')
+
+        newRating1 = rating1 + k * (score1 - expected1)
+        newRating2 = rating2 + k * (score2 - expected2)
+
+        if newRating1 < 0:
+            newRating1 = 0
+            newRating2 = rating2 - rating1
+
+        elif newRating2 < 0:
+            newRating2 = 0
+            newRating1 = rating1 - rating2
+
+        player1.rating = newRating1
+        player2.rating = newRating2
+
+    def getPlayerRating(self, name):
+        """
+        Returns the rating of the player with the given name.
+        @param name - name of the player.
+        @return - the rating of the player with the given name.
+        """
+        player = self.getPlayer(name)
+        return player.rating
+
+    def getRatingList(self):
+        """
+        Returns a list of tuples in the form of ({name},{rating})
+        @return - the list of tuples
+        """
+        lst = []
+        for player in self.__getPlayerList():
+            lst.append((player.name,player.rating))
+        return lst
+
+class _Player:
+    """
+    A class to represent a player in the Elo Rating System
+    """
+
+    def __init__(self, name, rating):
+        """
+        Runs at initialization of class object.
+        @param name - TODO
+        @param rating - TODO
+        """
+        self.name = name
+        self.rating = rating
+
+    def compareRating(self, opponent):
+        """
+        Compares the two ratings of the this player and the opponent.
+        @param opponent - the player to compare against.
+        @returns - The expected score between the two players.
+        """
+        return ( 1+10**( ( opponent.rating-self.rating )/400.0 ) ) ** -1

--- a/examples/summarize_scoring_using_bedrock.ipynb
+++ b/examples/summarize_scoring_using_bedrock.ipynb
@@ -113,33 +113,71 @@
     "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
     "    )\n",
     "    response_body = json.loads(response.get(\"body\").read())\n",
-    "    return response_body.get(\"results\")[0].get(\"outputText\")"
+    "    return response_body.get(\"results\")[0].get(\"outputText\")\n",
+    "\n",
+    "\n",
+    "def generate_summary_from_claude(model_id, article):\n",
+    "    body = json.dumps({\n",
+    "        \"prompt\": f\"Human:\\n{prompt.format(article)}\\nAssistant:\\n\",\n",
+    "        \"max_tokens_to_sample\": 4000,  # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html\n",
+    "    })\n",
+    "    modelId = model_id\n",
+    "    accept = \"application/json\"\n",
+    "    contentType = \"application/json\"\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
+    "    return response_body.get(\"completion\")    "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b70fcc4-5396-4733-9a93-785c6a53b893",
+   "id": "4f76d25c-7241-48db-9c82-e00335d6da29",
    "metadata": {},
    "outputs": [],
    "source": [
     "models = (\n",
     "    \"meta.llama2-13b-chat-v1\",\n",
     "    \"meta.llama2-70b-chat-v1\",\n",
-    "    \"amazon.titan-text-lite-v1\"\n",
-    ")\n",
-    "\n",
-    "summaries = {}\n",
-    "summaries[\"input\"] = articles\n",
-    "\n",
-    "for model in models:\n",
+    "    \"amazon.titan-text-lite-v1\",\n",
+    "    \"anthropic.claude-v2\",\n",
+    "    \"anthropic.claude-v1\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea41fa3a-13c8-4c07-89f5-6b5e2e58edcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "summaries = defaultdict(list)\n",
+    "summaries[\"input\"] = articles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b94c7974-410e-4c7c-b213-9555cc8c0871",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for model in [m for m in models if m not in summaries.keys()]:\n",
     "    summaries.setdefault(model, [])\n",
-    "    for i, article in enumerate(articles): \n",
+    "    for i, article in enumerate(articles):         \n",
     "        try:\n",
+    "            print(f\"Generating summary for article {i} using model {model}\")\n",
     "            if \"meta\" in model:\n",
     "                summary = generate_summary_from_llama(model, article)\n",
     "            elif \"amazon\" in model:\n",
     "                summary = generate_summary_from_titan(model, article)\n",
+    "            elif \"claude\" in model:\n",
+    "                summary = generate_summary_from_claude(model, article)\n",
     "            else:\n",
     "                print(f\"Unable to determine what {model} is\")\n",
     "                continue\n",
@@ -147,8 +185,8 @@
     "            summaries[model].append(summary)\n",
     "        except:\n",
     "            print(f\"Couldn't generate summary for article {i} using model {model}\")\n",
-    "            summaries[model].append(\"\")\n",
-    "            continue\n"
+    "            summaries[model].append(\"Unable to summarize\")\n",
+    "            continue"
    ]
   },
   {
@@ -175,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d779158-1319-4baf-94a7-b742e401133f",
+   "id": "c32024ed-aa38-42bf-81d7-805dc7d68c58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,9 +227,9 @@
    "id": "54947f69-7b97-467f-bf09-86eac0c8198d",
    "metadata": {},
    "source": [
-    "## 4. Setup a Bench TestSuite and run Bench TestRuns\n",
+    "## 4. Setup Bench TestSuites for each model and run Bench TestRuns\n",
     "\n",
-    "At this point, make sure you've set the `BENCH_FILE_DIR` environment variable. \n",
+    "The below sets up TestSuites + Runs for each unique combination so we have the ability to rank the models in a round-robin tournament for ELO rating. \n",
     "\n",
     "See the [Quickstart Guide](https://bench.readthedocs.io/en/latest/quickstart.html#view-results-in-local-ui) for additional information."
    ]
@@ -199,58 +237,114 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3511884e-dc11-4c06-a4be-6c8cc5ae61d8",
+   "id": "89e53792-7c88-41d4-a778-29aeab195f3f",
    "metadata": {},
    "outputs": [],
    "source": [
     "from arthur_bench.run.testsuite import TestSuite\n",
-    "import os \n",
+    "from itertools import combinations\n",
+    "from collections import defaultdict\n",
     "\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"REPLACE_ME\"\n",
     "\n",
+    "# Make sure you've set the BENCH_FILE_DIR environment variable\n",
     "\n",
-    "suite = TestSuite(\n",
-    "    \"News Summarization Using Bedrock\", \n",
-    "    'summary_quality',\n",
-    "    input_text_list=summaries[\"input\"],\n",
-    "    reference_output_list=summaries[\"amazon.titan-text-lite-v1\"]  # Use Titan's summarization as our \"reference\"\n",
-    ")"
+    "# The summary_quality scorer uses ChatGPT to score the summary\n",
+    "# so make sure that your OPENAI_API_KEY environment variable is set\n",
+    "\n",
+    "combos = list(combinations(models, 2))\n",
+    "d_combos = defaultdict(list)\n",
+    "for m1, m2 in combos:\n",
+    "    d_combos[m1].append(m2)\n",
+    "\n",
+    "print(d_combos)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c54cd40d-80dc-4ad2-aded-a7a491a33887",
+   "id": "ec69abd6-5aa6-4a40-9f79-00f9505fcb59",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Compare titan's summarization against llama 13b\n",
-    "run_llama_13b_compare = suite.run(\n",
-    "    run_name=\"titan_vs_llama_13b\",\n",
-    "    candidate_output_list=summaries[\"meta.llama2-13b-chat-v1\"]\n",
-    ")\n",
+    "def create_test_suite(model):\n",
+    "    print(f\"Creating test suite for model {model}\")\n",
+    "    return TestSuite(\n",
+    "        f\"News Summarization using {model} as reference\", \n",
+    "        'summary_quality',\n",
+    "        input_text_list=summaries[\"input\"],\n",
+    "        reference_output_list=summaries[model]\n",
+    "    )    \n",
     "\n",
-    "# Compare titan's summarization against llama 70b\n",
-    "run_llama_13b_compare = suite.run(\n",
-    "    run_name=\"titan_vs_llama_70b\",\n",
-    "    candidate_output_list=summaries[\"meta.llama2-70b-chat-v1\"]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a25fe8fb-d663-4170-96d4-288b214c115d",
-   "metadata": {},
-   "source": [
-    "# 5. Open the Bench UI and view your results\n",
-    "\n",
-    "From your command line, enter the `bench` command and load the UI from the URL output in your terminal window"
+    "suites = {}\n",
+    "for model in d_combos.keys():\n",
+    "    suites[model] = create_test_suite(model)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ecd1d19-aa92-4818-bbb2-be5bdce980ff",
+   "id": "09afb482-cbb7-43fe-8f3b-804bd0691d2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_test_suite(suite, ref_model, cand_model):\n",
+    "    run = suite.run(\n",
+    "        run_name=f\"{ref_model}_vs_{cand_model}\",\n",
+    "        candidate_output_list=summaries[cand_model]\n",
+    "    )\n",
+    "    return run\n",
+    "\n",
+    "runs = defaultdict(dict)\n",
+    "for ref_model, suite in suites.items():\n",
+    "    for cand_model in d_combos[ref_model]:\n",
+    "        runs[ref_model][cand_model] = run_test_suite(suite, ref_model, cand_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1f1185e4-b39d-4107-bbc4-3aedc449cf46",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('anthropic.claude-v2', 1345.4153155340496), ('meta.llama2-70b-chat-v1', 1079.6979024278733), ('amazon.titan-text-lite-v1', 898.4211374051577), ('anthropic.claude-v1', 864.5103513782595), ('meta.llama2-13b-chat-v1', 811.9552932546615)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from elo import Implementation\n",
+    "\n",
+    "i = Implementation()\n",
+    "for model in models:\n",
+    "    i.addPlayer(model)\n",
+    "\n",
+    "for ref_model in runs.keys():\n",
+    "    for cand_model, run in runs[ref_model].items():\n",
+    "        for test_case in run.test_cases:\n",
+    "            score = test_case.score\n",
+    "            if score == 1.0: \n",
+    "                i.recordMatch(ref_model, cand_model, winner=cand_model)\n",
+    "            if score == 0.5: \n",
+    "                i.recordMatch(ref_model, cand_model, draw=True)\n",
+    "            if score == 0.0:\n",
+    "                i.recordMatch(ref_model, cand_model, winner=ref_model)\n",
+    "            else:\n",
+    "                pass\n",
+    "\n",
+    "sorted_list = sorted(i.getRatingList(), key=lambda x: x[1], reverse=True)\n",
+    "\n",
+    "# Output the sorted list\n",
+    "for model, score in sorted_list:\n",
+    "    print(f\"Model {model}: Rating {score}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b321949-059f-495e-8bb7-7d4abb96507b",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/summarize_scoring_using_bedrock.ipynb
+++ b/examples/summarize_scoring_using_bedrock.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "68397145-e13d-4e6d-bb0a-35944409c333",
+   "metadata": {},
+   "source": [
+    "# Summarization Scoring using AWS Bedrock\n",
+    "\n",
+    "In this example notebook, we will be comparing how different models in AWS Bedrock perform at summarization tasks using **Arthur Bench**. \n",
+    "\n",
+    "The overall summarization comparison is setup as a **Bench TestSuite**, and each model is compared head-to-head against every other model\n",
+    "in a **Bench TestRun**. Bench provides the ability to view these comparisons in the provided User Interface, as well as access statistics\n",
+    "from the Test and TestRuns themselves for further analysis. For example, in the notebook below we provide a means for using the ELO Scoring\n",
+    "Algorithm to determine which model performs best at this summarization task. \n",
+    "                                                                                                                 \n",
+    "The task is to summarize 49 News Articles, and comparison is done using ChatGPT 3.5 Turbo (see summary_quality.py)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c97dda90-22a7-4a8d-8cf5-e2948d35f8af",
+   "metadata": {},
+   "source": [
+    "## 1. Setup AWS Bedrock Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d375f148-b8f3-4a6d-8a10-f4e96e97ce90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "Authentication is handled using the AWS_PROFILE environment variable. Check the AWS Boto3 documentation and the provided\n",
+    "utility library for connecting to Bedrock for additional information\n",
+    "\"\"\"\n",
+    "from bedrock_client import client\n",
+    "\n",
+    "bedrock_runtime = client.get_bedrock_client(region=\"us-east-1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11b3eeae-afa0-474b-974b-bcaa716d83c8",
+   "metadata": {},
+   "source": [
+    "## 2. Load the data and prepare it for inferencing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfee14bb-017d-4057-a406-1f0cc60e5bee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "\n",
+    "articles = []\n",
+    "\n",
+    "with open(\"data/news_summary/example_summaries.csv\", \"r\") as f:\n",
+    "    dr = csv.DictReader(f)\n",
+    "    for row in dr: \n",
+    "        articles.append(row[\"input_text\"])\n",
+    "\n",
+    "len(articles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff9d4a64-1fc0-493c-b7d5-556d4174313e",
+   "metadata": {},
+   "source": [
+    "## 3. Generate inferences (summaries) for the articles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6d18def-3fe4-4eba-aacc-0882cf123bd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "prompt = \"\"\"\\\n",
+    "Summarize the following news document down to its most important points in less than 250 words.\n",
+    "{}\n",
+    "\"\"\"\n",
+    "\n",
+    "def generate_summary_from_llama(model_id, article): \n",
+    "    body = json.dumps({\"prompt\": prompt.format(article)})\n",
+    "    modelId = model_id\n",
+    "    accept = \"application/json\"\n",
+    "    contentType = \"application/json\"\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
+    "    return response_body.get(\"generation\")\n",
+    "\n",
+    "\n",
+    "def generate_summary_from_titan(model_id, article):\n",
+    "    body = json.dumps({\"inputText\": prompt.format(article)})\n",
+    "    modelId = model_id\n",
+    "    accept = \"application/json\"\n",
+    "    contentType = \"application/json\"\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
+    "    return response_body.get(\"results\")[0].get(\"outputText\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b70fcc4-5396-4733-9a93-785c6a53b893",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models = (\n",
+    "    \"meta.llama2-13b-chat-v1\",\n",
+    "    \"meta.llama2-70b-chat-v1\",\n",
+    "    \"amazon.titan-text-lite-v1\"\n",
+    ")\n",
+    "\n",
+    "summaries = {}\n",
+    "summaries[\"input\"] = articles\n",
+    "\n",
+    "for model in models:\n",
+    "    summaries.setdefault(model, [])\n",
+    "    for i, article in enumerate(articles): \n",
+    "        try:\n",
+    "            if \"meta\" in model:\n",
+    "                summary = generate_summary_from_llama(model, article)\n",
+    "            elif \"amazon\" in model:\n",
+    "                summary = generate_summary_from_titan(model, article)\n",
+    "            else:\n",
+    "                print(f\"Unable to determine what {model} is\")\n",
+    "                continue\n",
+    "                \n",
+    "            summaries[model].append(summary)\n",
+    "        except:\n",
+    "            print(f\"Couldn't generate summary for article {i} using model {model}\")\n",
+    "            summaries[model].append(\"\")\n",
+    "            continue\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7649fcb0-7e11-4002-9bed-e9c2185112a1",
+   "metadata": {},
+   "source": [
+    "### 3.5 Save (and load) inferences to a pickle file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8aad5571-e159-4559-883c-06eeb9f81f6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle\n",
+    "\n",
+    "with open(\"summaries.pkl\", \"wb\") as f:\n",
+    "    pickle.dump(summaries, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d779158-1319-4baf-94a7-b742e401133f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle\n",
+    "with open('summaries.pkl', 'rb') as f:\n",
+    "    summaries = pickle.load(f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54947f69-7b97-467f-bf09-86eac0c8198d",
+   "metadata": {},
+   "source": [
+    "## 4. Setup a Bench TestSuite and run Bench TestRuns\n",
+    "\n",
+    "At this point, make sure you've set the `BENCH_FILE_DIR` environment variable. \n",
+    "\n",
+    "See the [Quickstart Guide](https://bench.readthedocs.io/en/latest/quickstart.html#view-results-in-local-ui) for additional information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3511884e-dc11-4c06-a4be-6c8cc5ae61d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from arthur_bench.run.testsuite import TestSuite\n",
+    "import os \n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"REPLACE_ME\"\n",
+    "\n",
+    "\n",
+    "suite = TestSuite(\n",
+    "    \"News Summarization Using Bedrock\", \n",
+    "    'summary_quality',\n",
+    "    input_text_list=summaries[\"input\"],\n",
+    "    reference_output_list=summaries[\"amazon.titan-text-lite-v1\"]  # Use Titan's summarization as our \"reference\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c54cd40d-80dc-4ad2-aded-a7a491a33887",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare titan's summarization against llama 13b\n",
+    "run_llama_13b_compare = suite.run(\n",
+    "    run_name=\"titan_vs_llama_13b\",\n",
+    "    candidate_output_list=summaries[\"meta.llama2-13b-chat-v1\"]\n",
+    ")\n",
+    "\n",
+    "# Compare titan's summarization against llama 70b\n",
+    "run_llama_13b_compare = suite.run(\n",
+    "    run_name=\"titan_vs_llama_70b\",\n",
+    "    candidate_output_list=summaries[\"meta.llama2-70b-chat-v1\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a25fe8fb-d663-4170-96d4-288b214c115d",
+   "metadata": {},
+   "source": [
+    "# 5. Open the Bench UI and view your results\n",
+    "\n",
+    "From your command line, enter the `bench` command and load the UI from the URL output in your terminal window"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ecd1d19-aa92-4818-bbb2-be5bdce980ff",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This MR adds a demo showing how a user can use Bench to compare performance of models hosted in AWS Bedrock. 

The specific scoring methodology used is the `summary_quality` score, and the dataset is composed of news articles. The LLMs generate a summary of the article in less than 250 words, and then Bench is used to compare which LLM generated a better summary. 

The notebook: 
* Creates a AWS Bedrock Client
* Loads 49 news articles
* Runs summarization inference tasks against LLMs hosted in Bedrock
* Creates bench test suites and runs comparing each unique combination of models' summaries
* Generates an ELO rating, using each summary task for each model, of the models performance measured against other models

The final ELO rating output for each model is as follows: 

```
Model anthropic.claude-v2: Rating 1345.4153155340496
Model meta.llama2-70b-chat-v1: Rating 1079.6979024278733
Model amazon.titan-text-lite-v1: Rating 898.4211374051577
Model anthropic.claude-v1: Rating 864.5103513782595
Model meta.llama2-13b-chat-v1: Rating 811.9552932546615
```